### PR TITLE
Properly export 'unescape'

### DIFF
--- a/lib/String/Unescape.pm
+++ b/lib/String/Unescape.pm
@@ -6,8 +6,7 @@ use warnings;
 
 # ABSTRACT: Unescape perl-escaped string
 # VERSION
-
-require Exporter;
+use Exporter 'import';
 our (@EXPORT_OK) = qw(unescape);
 
 use Carp;


### PR DESCRIPTION
$ perl -v
This is perl 5, version 22, subversion 1 (v5.22.1) built for x86_64-linux-gnu-thread-multi
$ perl -MString::Unescape=unescape -E 'say unescape("Hey\\nThere")'
Undefined subroutine &main::unescape called at -e line 1.